### PR TITLE
Change loop to if check

### DIFF
--- a/reactionmenu/core.py
+++ b/reactionmenu/core.py
@@ -704,10 +704,8 @@ class ReactionMenu:
 		
 			.. Added v1.0.1
 		"""
-		for curr_menu in cls._active_sessions:
-			if curr_menu == menu:
-				cls._active_sessions.remove(menu)
-				return
+		if menu in cls._active_sessions:
+			cls._active_sessions.remove(menu)
 	
 	@classmethod
 	def set_sessions_limit(cls, limit: int, message: str='Too many active reaction menus. Wait for other menus to be finished.'):


### PR DESCRIPTION
Instead of looping over each menu in the `cls._active_sessions` list the presence of `menu` in the active sessions list is checked.