### PR TITLE
Import only the needed two errors

### DIFF
--- a/reactionmenu/decorators.py
+++ b/reactionmenu/decorators.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 import inspect
 from functools import wraps
-from .errors import *
+from .errors import MenuSettingsMismatch, MenuAlreadyRunning
 from . import core
 
 


### PR DESCRIPTION
Importing all of the errors clutters the namespace. Instead only the two needed errors are imported (out of a dozen or so).